### PR TITLE
Feat. Show Accounting For All Users

### DIFF
--- a/nomad-front-end/src/components/AccountsComponents/AccountsForm.jsx
+++ b/nomad-front-end/src/components/AccountsComponents/AccountsForm.jsx
@@ -11,11 +11,13 @@ const AccountsForm = props => {
 
   useEffect(() => form.resetFields(), [type])
 
-  const grpOptions = props.groupList.map(grp => (
+  let grpOptions = props.groupList.map(grp => (
     <Option value={grp.id} key={grp.id}>
       {grp.name}
     </Option>
   ))
+
+  grpOptions = [ <Option value='all' key='all' >--all--</Option> , ...grpOptions ]
 
   const radioOptions = ['Grants', 'Groups', 'Users']
 
@@ -70,7 +72,7 @@ const AccountsForm = props => {
         />
       </Space>
       <Form.Item label='Group' name='groupId'>
-        <Select style={{ width: 150 }} disabled={type !== 'Users'}>
+        <Select  loading={props.groupList.length === 0} style={{ width: 150 }} disabled={type !== 'Users'}>
           {grpOptions}
         </Select>
       </Form.Item>

--- a/nomad-front-end/src/components/Credits/Credits.module.css
+++ b/nomad-front-end/src/components/Credits/Credits.module.css
@@ -9,6 +9,7 @@
   font-weight: 600;
   position: fixed;
   bottom: 0;
+  z-index: 3;
   left: 0;
   width: 100%;
 }

--- a/nomad-rest-api/controllers/admin/accounts.js
+++ b/nomad-rest-api/controllers/admin/accounts.js
@@ -64,9 +64,12 @@ export async function getCosts(req, res) {
       )
     } else {
       //each entry of the table is user
+      if (groupId !== 'all') {
+        //add the groupid filter if all users are not requested
+        searchParams.$and = [...searchParams.$and, { 'group.id': groupId }]
+        searchParamsClaims.$and = [...searchParamsClaims.$and, { group: groupId }]
+      }
 
-      searchParams.$and = [...searchParams.$and, { 'group.id': groupId }]
-      searchParamsClaims.$and = [...searchParamsClaims.$and, { group: groupId }]
 
       const expArray = await Experiment.find(searchParams, 'instrument totalExpTime user')
       const claimsArray = await Claim.find(searchParamsClaims, 'instrument expTime user')


### PR DESCRIPTION
fixes #120 
Took very few changes, added the backend logic so that the the `groupid` filter is only added to the query when `--all--` option is not selected. Also fixed a minor UI bug, can be seen in the last commit.