### PR TITLE
Sort parameterSets by description in dropdown

### DIFF
--- a/nomad-front-end/src/components/Forms/BookExperimentsForm/BookExperimentsForm.jsx
+++ b/nomad-front-end/src/components/Forms/BookExperimentsForm/BookExperimentsForm.jsx
@@ -356,7 +356,7 @@ const BookExperimentsForm = props => {
 
         const dayQueueRemains = Math.round(
           moment.duration(moment(nightStart, 'HH:mm').diff(moment())).as('minutes') -
-            moment.duration(dayExpt, 'HH:mm').as('minutes')
+          moment.duration(dayExpt, 'HH:mm').as('minutes')
         )
 
         if (
@@ -402,11 +402,14 @@ const BookExperimentsForm = props => {
     const filteredParamSetArr = props.paramSetsData.filter(paramSet =>
       paramSet.availableOn.includes(sample.instId.toString())
     )
-    const paramSetsOptions = filteredParamSetArr.map((paramSet, i) => (
-      <Option value={paramSet.name} key={i}>
-        {`${paramSet.description} [${paramSet.name}]`}
-      </Option>
-    ))
+    const paramSetsOptions = filteredParamSetArr
+      .slice()
+      .sort((a, b) => a.description.localeCompare(b.description))
+      .map((paramSet, i) => (
+        <Option value={paramSet.name} key={i}>
+          {`${paramSet.description} [${paramSet.name}]`}
+        </Option>
+      ))
 
     //changing style of totalExpt time according to allowance state
     const totalExptClass = [classes.TotalExptBasic]


### PR DESCRIPTION
We have a lot of parameterSets, and the list is only growing. It can be difficult to find the one we want in the dropdown when submitting an experiment because they are ordered by (I think) date added. 

This is a simple change to order the parameterSets alphabetically by description - because they're formatted as `Description [name]` - in the BookExperimentsForm, hopefully without affecting any other code functionality. 

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/5644dc51-ff03-4946-b47c-c9e136965179" />

<img width="1714" alt="image" src="https://github.com/user-attachments/assets/a8ac5456-db01-4167-938f-8aa1e65f1de2" />

Note: you may prefer to handle this in Submit.jsx and paramSets.js, but this was slightly beyond my JS knowledge, and I wasn't sure what other parts of the code might be affected. 
