### PR TITLE
Update/timed experiment allowances

### DIFF
--- a/nomad-front-end/src/components/Forms/BookExperimentsForm/BookExperimentsForm.jsx
+++ b/nomad-front-end/src/components/Forms/BookExperimentsForm/BookExperimentsForm.jsx
@@ -498,6 +498,7 @@ const BookExperimentsForm = props => {
 
           return Modal.error({
             title: 'Night experiment too long for timed schedule',
+            width: 600,
             content: (
               <div>
                 <p>

--- a/nomad-front-end/src/components/Forms/BookExperimentsForm/BookExperimentsForm.jsx
+++ b/nomad-front-end/src/components/Forms/BookExperimentsForm/BookExperimentsForm.jsx
@@ -319,8 +319,11 @@ const BookExperimentsForm = props => {
     setTimingModalData({
       sampleKey: key,
       initialDelay: form.getFieldValue([key, 'initialDelay']) ?? '00:00',
-      repeatLoops: form.getFieldValue([key, 'repeatLoops']) ?? [{ lag: '00:00', count: 0 }]
+      repeatLoops: form.getFieldValue([key, 'repeatLoops']) ?? [{ lag: '00:00', count: 0 }],
+      baseTotalSeconds: totalExptState[key] || 0,
+      oneSetSeconds: getExperimentSetSeconds(key, exptState)
     })
+
     setTimingModalVisible(true)
   }
 
@@ -799,3 +802,10 @@ const getExptAccumulator = (formValues, totalExptState, nightOption) => {
 }
 
 export default BookExperimentsForm
+
+//Helper function that sums totalExpT stored in state for all experiments of a sample
+const getExperimentSetSeconds = (sampleKey, exptState) => {
+  return Object.entries(exptState)
+    .filter(([key]) => key.startsWith(`${sampleKey}#`))
+    .reduce((sum, [, expTime]) => sum + moment.duration(expTime).asSeconds(), 0)
+}

--- a/nomad-front-end/src/components/Forms/BookExperimentsForm/BookExperimentsForm.jsx
+++ b/nomad-front-end/src/components/Forms/BookExperimentsForm/BookExperimentsForm.jsx
@@ -475,6 +475,54 @@ const BookExperimentsForm = props => {
         }
       }
 
+      // Checking if night experiments fit into active timed experiment gaps returned by backend
+      for (let sampleKey in values) {
+        const instrId = sampleKey.split('-')[0]
+        const allowanceDataInstr = allowanceData.find(i => i.instrId === instrId)
+        const timedNightMaxExperimentSeconds = allowanceDataInstr?.timedNightMaxExperimentSeconds
+
+        if (!timedNightMaxExperimentSeconds || !values[sampleKey].night) {
+          continue
+        }
+
+        const sampleDurationSeconds = totalExptState[sampleKey] || 0
+
+        if (sampleDurationSeconds > timedNightMaxExperimentSeconds) {
+          const sampleDurationFormatted = moment
+            .duration(sampleDurationSeconds, 'seconds')
+            .format('HH:mm:ss', { trim: false })
+
+          const timedNightMaxFormatted = moment
+            .duration(timedNightMaxExperimentSeconds, 'seconds')
+            .format('HH:mm:ss', { trim: false })
+
+          return Modal.error({
+            title: 'Night experiment too long for timed schedule',
+            content: (
+              <div>
+                <p>
+                  A timed experiment is currently booked on this instrument. Night experiments must fit
+                  into the gap between timed experiment runs.
+                </p>
+
+                <ul>
+                  <li>
+                    <strong>Maximum allowed night experiment duration:</strong> {timedNightMaxFormatted}
+                  </li>
+                  <li>
+                    <strong>This experiment duration:</strong> {sampleDurationFormatted}
+                  </li>
+                </ul>
+
+                <p>Please reduce the experiment time or submit it to another instrument.</p>
+              </div>
+            )
+          })
+        }
+      }
+
+
+
       if (nightExpSubmit) {
         return Modal.confirm(nightQueueWarning)
       }

--- a/nomad-front-end/src/components/Modals/TimedExperimentsModal/TimedExperimentsModal.jsx
+++ b/nomad-front-end/src/components/Modals/TimedExperimentsModal/TimedExperimentsModal.jsx
@@ -1,174 +1,236 @@
 import React, { useEffect } from 'react'
 import { Modal, Form, Input, InputNumber, Row, Col, Button, Space } from 'antd'
 import { PlusOutlined, MinusCircleOutlined } from '@ant-design/icons'
+import moment from 'moment'
 
 const TimedExperimentsModal = props => {
   const [form] = Form.useForm()
-  const { sampleKey, initialDelay, repeatLoops } = props.inputData
+  const {
+    sampleKey,
+    initialDelay: inputInitialDelay,
+    repeatLoops: inputRepeatLoops,
+    baseTotalSeconds = 0,
+    oneSetSeconds = 0
+  } = props.inputData
+
+  const watchedInitialDelay = Form.useWatch([sampleKey, 'initialDelay'], form)
+  const watchedRepeatLoops = Form.useWatch([sampleKey, 'repeatLoops'], form)
+
+  const currentInitialDelay = watchedInitialDelay ?? inputInitialDelay ?? '00:00'
+  const currentRepeatLoops =
+    watchedRepeatLoops?.length > 0
+      ? watchedRepeatLoops
+      : inputRepeatLoops?.length > 0
+        ? inputRepeatLoops
+        : [{ lag: '00:00', count: 0 }]
+
+  const timedEstimateSeconds = getTimedEstimateSeconds({
+    baseTotalSeconds,
+    oneSetSeconds,
+    initialDelay: currentInitialDelay,
+    repeatLoops: currentRepeatLoops
+  })
+
+  const timedEstimateMinutes = Math.ceil(timedEstimateSeconds / 60)
+
+  const estimatedEndTime = moment()
+    .add(timedEstimateMinutes, 'minutes')
+    .format('DD/MM/YYYY HH:mm')
 
   useEffect(() => {
     if (props.visible && sampleKey) {
       form.setFieldsValue({
         [sampleKey]: {
-          initialDelay: initialDelay ?? '00:00',
+          initialDelay: inputInitialDelay ?? '00:00',
           repeatLoops:
-            repeatLoops?.length > 0
-              ? repeatLoops
-              : [{ lag: '00:00', count: 0 }]
+            inputRepeatLoops?.length > 0 ? inputRepeatLoops : [{ lag: '00:00', count: 0 }]
         }
       })
     }
-  }, [props.visible, sampleKey, initialDelay, repeatLoops, form])
+  }, [props.visible, sampleKey, inputInitialDelay, inputRepeatLoops, form])
 
   return (
-  <Modal
-    title='Setup Timed Experiments'
-    open={props.visible}
-    footer={null}
-    onCancel={props.closeModal}
-  >
-    {sampleKey && (
-      <Form form={form} size='small' onFinish={props.onOkHandler}>
-        <Row gutter={16} align='middle'>
-          <Col span={10}>
-            <strong>Initial Delay</strong>
-          </Col>
-          <Col span={10}>
-            <Form.Item      
-              name={[sampleKey, 'initialDelay']}
-              style={{ marginBottom: 12 }}
-              rules={[
-                {
-                  validator: (_, value) => {
-                    if (!value || /^([01]\d|2[0-3]):([0-5]\d)$/.test(value)) {
-                      return Promise.resolve()
+    <Modal
+      title='Setup Timed Experiments'
+      open={props.visible}
+      footer={null}
+      onCancel={props.closeModal}
+    >
+      {sampleKey && (
+        <Form form={form} size='small' onFinish={props.onOkHandler}>
+          <Row gutter={16} align='middle'>
+            <Col span={10}>
+              <strong>Initial Delay</strong>
+            </Col>
+            <Col span={10}>
+              <Form.Item
+                name={[sampleKey, 'initialDelay']}
+                style={{ marginBottom: 12 }}
+                rules={[
+                  {
+                    validator: (_, value) => {
+                      if (!value || /^([01]\d|2[0-3]):([0-5]\d)$/.test(value)) {
+                        return Promise.resolve()
+                      }
+                      return Promise.reject(new Error('Use HH:mm format'))
                     }
-                    return Promise.reject(new Error('Use HH:mm format'))
                   }
-                }
-              ]}
-            >
-              <Input placeholder='HH:mm' style={{ width: 80 }} />
-            </Form.Item>  
-          </Col>
-          <Col span={4} />
-        </Row>
+                ]}
+              >
+                <Input placeholder='HH:mm' style={{ width: 80 }} />
+              </Form.Item>
+            </Col>
+            <Col span={4} />
+          </Row>
 
+          <Row gutter={16} align='middle' style={{ marginBottom: 4 }}>
+            <Col span={10}>
+              <strong>Delay between experiments</strong>
+            </Col>
+            <Col span={10}>
+              <strong>Loop Count</strong>
+            </Col>
+            <Col span={4} />
+          </Row>
 
-
-
-
-
-        <Row gutter={16} align='middle' style={{ marginBottom: 4 }}>
-          <Col span={10}>
-            <strong>Delay between experiments </strong>
-          </Col>
-          <Col span={10}>
-            <strong>Loop Count</strong>
-          </Col>
-          <Col span={4} />
-        </Row>
-
-        <Form.List name={[sampleKey, 'repeatLoops']}>
-          {(fields, { add, remove }) => (
-            <>
-              {fields.map(field => (
-                <Row gutter={16} key={field.key} align='middle'>
-                  <Col span={10}>
-                    <Form.Item
-                      name={[field.name, 'lag']}
-                      style={{ marginBottom: 8 }}
-                      rules={[
-                        {
-                          validator: (_, value) => {
-                            if (!value || /^([01]\d|2[0-3]):([0-5]\d)$/.test(value)) {
-                              return Promise.resolve()
+          <Form.List name={[sampleKey, 'repeatLoops']}>
+            {(fields, { add, remove }) => (
+              <>
+                {fields.map(field => (
+                  <Row gutter={16} key={field.key} align='middle'>
+                    <Col span={10}>
+                      <Form.Item
+                        name={[field.name, 'lag']}
+                        style={{ marginBottom: 8 }}
+                        rules={[
+                          {
+                            validator: (_, value) => {
+                              if (!value || /^([01]\d|2[0-3]):([0-5]\d)$/.test(value)) {
+                                return Promise.resolve()
+                              }
+                              return Promise.reject(new Error('Use HH:mm format'))
                             }
-                            return Promise.reject(new Error('Use HH:mm format'))
                           }
-                        }
-                      ]}
-                    >
-                      <Input placeholder='HH:mm' style={{ width: 80 }} />
-                    </Form.Item>
+                        ]}
+                      >
+                        <Input placeholder='HH:mm' style={{ width: 80 }} />
+                      </Form.Item>
+                    </Col>
 
-                  </Col>
+                    <Col span={10}>
+                      <Form.Item
+                        name={[field.name, 'count']}
+                        style={{ marginBottom: 8 }}
+                        rules={[
+                          {
+                            required: true,
+                            message: 'Enter a loop count'
+                          }
+                        ]}
+                      >
+                        <InputNumber min={0} style={{ width: 80 }} />
+                      </Form.Item>
+                    </Col>
 
-                  <Col span={10}>
-                    <Form.Item
-                      name={[field.name, 'count']}
-                      style={{ marginBottom: 8 }}
-                      rules={[
-                        {
-                          required: true,
-                          message: 'Enter a loop count'
-                        }
-                      ]}
-                    >
-                      <InputNumber min={0} style={{ width: 80 }} />
-                    </Form.Item>
-                  </Col>
+                    <Col span={4}>
+                      {fields.length > 1 && (
+                        <Button
+                          type='text'
+                          danger
+                          icon={<MinusCircleOutlined />}
+                          onClick={() => remove(field.name)}
+                        />
+                      )}
+                    </Col>
+                  </Row>
+                ))}
 
-                  <Col span={4}>
-                    {fields.length > 1 && (
+                <Row>
+                  <Col span={24}>
+                    <Form.Item style={{ marginTop: 8 }}>
                       <Button
-                        type='text'
-                        danger
-                        icon={<MinusCircleOutlined />}
-                        onClick={() => remove(field.name)}
-                      />
-                    )}
+                        type='dashed'
+                        onClick={() => add({ lag: '00:00', count: 0 })}
+                        icon={<PlusOutlined />}
+                        block
+                      >
+                        Add Loop
+                      </Button>
+                    </Form.Item>
                   </Col>
                 </Row>
-              ))}
+              </>
+            )}
+          </Form.List>
 
-              <Row>
-                <Col span={24}>
-                  <Form.Item style={{ marginTop: 8 }}>
-                    <Button
-                      type='dashed'
-                      onClick={() => add({ lag: '00:00', count: 0 })}
-                      icon={<PlusOutlined />}
-                      block
-                    >
-                      Add Loop
-                    </Button>
-                  </Form.Item>
-                </Col>
-              </Row>
-            </>
-          )}
-        </Form.List>
+          <Row justify='center' style={{ marginTop: 12, marginBottom: 8 }}>
+            <Col>
+              <strong>Estimated end time: </strong>
+              {estimatedEndTime}
+            </Col>
+          </Row>
 
-        <Row justify='center'>
-          <Form.Item style={{ marginTop: 12 }}>
-            <Space>
-              <Button type='primary' htmlType='submit'>
-                OK
-              </Button>
+          <Row justify='center'>
+            <Form.Item style={{ marginTop: 12 }}>
+              <Space>
+                <Button type='primary' htmlType='submit'>
+                  OK
+                </Button>
 
-              <Button
-                onClick={() => {
-                  form.setFieldsValue({
-                    [sampleKey]: {
-                      initialDelay: '00:00',
-                      repeatLoops: [{ lag: '00:00', count: 0 }]
-                    }
-                  })
-                }}
-              >
-                Reset
-              </Button>
+                <Button
+                  onClick={() => {
+                    form.setFieldsValue({
+                      [sampleKey]: {
+                        initialDelay: '00:00',
+                        repeatLoops: [{ lag: '00:00', count: 0 }]
+                      }
+                    })
+                  }}
+                >
+                  Reset
+                </Button>
 
-              <Button onClick={props.closeModal}>Cancel</Button>
-            </Space>
-          </Form.Item>
-        </Row>
-      </Form>
-    )}
-  </Modal>
-)
-
+                <Button onClick={props.closeModal}>Cancel</Button>
+              </Space>
+            </Form.Item>
+          </Row>
+        </Form>
+      )}
+    </Modal>
+  )
 }
 
 export default TimedExperimentsModal
+
+const parseHHMMToSeconds = value => {
+  if (!value) return 0
+  const [hours = 0, minutes = 0] = value.split(':').map(Number)
+  return hours * 3600 + minutes * 60
+}
+
+const getRepeatCount = repeatLoops =>
+  Array.isArray(repeatLoops)
+    ? repeatLoops.reduce((sum, loop) => sum + (Number(loop?.count) || 0), 0)
+    : 0
+
+const getRepeatLagSeconds = repeatLoops =>
+  Array.isArray(repeatLoops)
+    ? repeatLoops.reduce(
+        (sum, loop) => sum + parseHHMMToSeconds(loop?.lag) * (Number(loop?.count) || 0),
+        0
+      )
+    : 0
+
+const getTimedEstimateSeconds = ({
+  baseTotalSeconds = 0,
+  oneSetSeconds = 0,
+  initialDelay,
+  repeatLoops
+}) => {
+  const initialDelaySeconds = parseHHMMToSeconds(initialDelay)
+  const repeatLagSeconds = getRepeatLagSeconds(repeatLoops)
+  const repeatCount = getRepeatCount(repeatLoops)
+  const repeatedRunSeconds = oneSetSeconds * repeatCount
+
+  return baseTotalSeconds + initialDelaySeconds + repeatLagSeconds + repeatedRunSeconds
+}

--- a/nomad-front-end/src/components/Modals/TimedExperimentsModal/TimedExperimentsModal.jsx
+++ b/nomad-front-end/src/components/Modals/TimedExperimentsModal/TimedExperimentsModal.jsx
@@ -105,11 +105,27 @@ const TimedExperimentsModal = props => {
                         rules={[
                           {
                             validator: (_, value) => {
-                              if (!value || /^([01]\d|2[0-3]):([0-5]\d)$/.test(value)) {
-                                return Promise.resolve()
-                              }
+                            if (!value) {
+                              return Promise.resolve()
+                            }
+
+                            if (!/^([01]\d|2[0-3]):([0-5]\d)$/.test(value)) {
                               return Promise.reject(new Error('Use HH:mm format'))
                             }
+
+                            const lagSeconds = parseHHMMToSeconds(value)
+
+                            if (lagSeconds > 0 && oneSetSeconds > 0 && lagSeconds < oneSetSeconds) {
+                              return Promise.reject(
+                                new Error(
+                                  `Delay must exceed ${formatSecondsAsHHMM(oneSetSeconds)}, the experiment time`
+                                )
+                              )
+                            }
+
+                            return Promise.resolve()
+                          }
+
                           }
                         ]}
                       >
@@ -234,3 +250,6 @@ const getTimedEstimateSeconds = ({
 
   return baseTotalSeconds + initialDelaySeconds + repeatLagSeconds + repeatedRunSeconds
 }
+
+const formatSecondsAsHHMM = seconds =>
+  moment.duration(seconds, 'seconds').format('HH:mm', { trim: false })

--- a/nomad-rest-api/controllers/submit.js
+++ b/nomad-rest-api/controllers/submit.js
@@ -38,6 +38,7 @@ export const postSubmission = async (req, res) => {
       const holder = formData[sampleKey].holder
 
       const experiments = []
+      let oneSetSeconds = 0 
       for (let expNo in formData[sampleKey].exps) {
         const paramSet = formData[sampleKey].exps[expNo].paramSet
         const paramSetObj = await ParameterSet.findOne({ name: paramSet })
@@ -47,14 +48,24 @@ export const postSubmission = async (req, res) => {
           expTitle: paramSetObj.description,
           params: formData[sampleKey].exps[expNo].params
         })
+        
+        if (paramSetObj.defaultParams?.[4]?.value) {
+          oneSetSeconds += moment.duration(paramSetObj.defaultParams[4].value).asSeconds()
+        }
+
         paramSetObj.count++
         paramSetObj.save()
       }
       const { night, solvent, title, priority, initialDelay, repeatLoops } = formData[sampleKey]
 
-      
+      const isTimedExperiment = hasTimedExperiments({ initialDelay, repeatLoops })
+
+      if (isTimedExperiment) {
+        await updateNightAllowanceForTimedExperiment({instrId, initialDelay, repeatLoops, oneSetSeconds})
+      }
+
       // check for timed experiments and add start times if necessary
-      const timedExperiments = hasTimedExperiments({ initialDelay, repeatLoops })
+      const timedExperiments = isTimedExperiment
         ? addTimedStartTimes(experiments, timeStamp, initialDelay, repeatLoops)
         : experiments
 
@@ -77,8 +88,6 @@ export const postSubmission = async (req, res) => {
         experiments: clientExperiments,
       }
 
-      //toremove
-      console.log('Sample Data:', sampleData)
 
       if (submitData[instrId]) {
         submitData[instrId].push(sampleData)
@@ -118,26 +127,22 @@ export const postSubmission = async (req, res) => {
           }
           const experiment = new Experiment(expHistObj)
 
-          //toremove
-          console.log('Experiment Data:', experiment)
-
           await experiment.save()
         })
       )
     }
 
-    // toremove - uncomment to test socket emit
-    // for (let instrumentId in submitData) {
-    //   //Getting socketId from submitter state
-    //   const { socketId } = submitter.state.get(instrumentId)
+    for (let instrumentId in submitData) {
+      //Getting socketId from submitter state
+      const { socketId } = submitter.state.get(instrumentId)
 
-    //   if (!socketId) {
-    //     console.log('Error: Client disconnected')
-    //     return res.status(503).send({ message: 'Client disconnected' })
-    //   }
+      if (!socketId) {
+        console.log('Error: Client disconnected')
+        return res.status(503).send({ message: 'Client disconnected' })
+      }
 
-    //   getIO().to(socketId).emit('book', JSON.stringify(submitData[instrumentId]))
-    // }
+      getIO().to(socketId).emit('book', JSON.stringify(submitData[instrumentId]))
+    }
 
 
 
@@ -335,22 +340,6 @@ export const getAllowance = async (req, res) => {
         const instr = await Instrument.findById(instrId)
         let { dayAllowance, nightAllowance, nightStart, nightEnd, overheadTime } = instr
 
-        const activeTimedExperiments = await Experiment.find({
-          'instrument.id': instrId,
-          // startTime: { $ne: null, $gte: new Date() }, this filters out experiments that start now.
-          startTime: { $ne: null },
-          status: { $in: ['Booked', 'Submitted', 'Available', 'Running'] }
-        }).sort({ datasetName: 1, startTime: 1 })
-
-        const timedNightMaxExperimentSeconds =
-          getTimedNightMaxExperimentSecondsByDataset(activeTimedExperiments)
-
-        console.log(
-          `Timed night max experiment duration for instrument ${instr.name}:`,
-          timedNightMaxExperimentSeconds
-        )
-
-
         const usrSamples = new Set()
 
         await Promise.all(
@@ -419,8 +408,7 @@ export const getAllowance = async (req, res) => {
           nightEnd,
           overheadTime,
           nightExpt: instr.status.summary.nightExpt,
-          dayExpt: instr.status.summary.dayExpt,
-          timedNightMaxExperimentSeconds
+          dayExpt: instr.status.summary.dayExpt
         })
       })
     )
@@ -600,69 +588,109 @@ const parseDelayToDuration = value => {
   return moment.duration({ hours, minutes })
 }
 
-// Calculates the smallest gap between start times for a single timed experiment dataset.
-// Duplicate start times are ignored because multiple experiments in the same set can share a start time.
-const getTimedNightMaxExperimentSeconds = experiments => {
-  if (!Array.isArray(experiments) || experiments.length < 2) {
+
+// helper function to calculate the maximum duration of timed experiments that occur during the night period
+const getMinimumTimedLagSeconds = repeatLoops => {
+  if (!Array.isArray(repeatLoops)) {
     return null
   }
 
-  const sortedStartTimes = experiments
-    .map(exp => exp.startTime)
-    .filter(Boolean)
-    .map(startTime => moment(startTime))
-    .filter(startTime => startTime.isValid())
-    .sort((a, b) => a.valueOf() - b.valueOf())
+  const positiveLagSeconds = repeatLoops
+    .map(loop => parseDelayToDuration(loop?.lag).asSeconds())
+    .filter(seconds => seconds > 0)
 
-  if (sortedStartTimes.length < 2) {
+  if (positiveLagSeconds.length === 0) {
     return null
   }
 
-  let minGapSeconds = null
-
-  for (let i = 1; i < sortedStartTimes.length; i++) {
-    const gapSeconds = sortedStartTimes[i].diff(sortedStartTimes[i - 1], 'seconds')
-
-    if (gapSeconds > 0 && (minGapSeconds === null || gapSeconds < minGapSeconds)) {
-      minGapSeconds = gapSeconds
-    }
-  }
-
-  return minGapSeconds
+  return Math.min(...positiveLagSeconds)
 }
 
-// Calculates the smallest timed repeat gap per dataset, then returns the smallest of those.
-// This avoids unrelated timed experiments on the same instrument creating artificial tiny gaps.
-const getTimedNightMaxExperimentSecondsByDataset = experiments => {
-  if (!Array.isArray(experiments) || experiments.length < 2) {
-    return null
+//he;per function to calculate the maximum duration of timed experiments that occur during the night period
+//reset the night allowance to the original value after the timed experiment duration has passed
+const updateNightAllowanceForTimedExperiment = async ({
+  instrId,
+  initialDelay,
+  repeatLoops,
+  oneSetSeconds
+}) => {
+  const minimumLagSeconds = getMinimumTimedLagSeconds(repeatLoops)
+
+  if (!minimumLagSeconds) {
+    return
   }
 
-  const experimentsByDataset = {}
+  const minimumLagMinutes = Math.floor(minimumLagSeconds / 60)
 
-  experiments.forEach(exp => {
-    if (!exp.datasetName || !exp.startTime) return
+  const instrument = await Instrument.findById(instrId)
 
-    if (!experimentsByDataset[exp.datasetName]) {
-      experimentsByDataset[exp.datasetName] = []
+  if (!instrument) {
+    throw new Error(`Instrument not found: ${instrId}`)
+  }
+
+  const originalNightAllowance = instrument.nightAllowance
+  const updatedNightAllowance = Math.min(originalNightAllowance, minimumLagMinutes)
+
+  instrument.nightAllowance = updatedNightAllowance
+
+  await instrument.save()
+
+  const timedExperimentTotalSeconds = getTimedEstimateSeconds({
+    oneSetSeconds,
+    initialDelay,
+    repeatLoops
+  })  
+
+  if (!timedExperimentTotalSeconds || timedExperimentTotalSeconds <= 0) {
+    return
+  }
+
+  setTimeout(async () => {
+    try {
+      const instrumentToReset = await Instrument.findById(instrId)
+
+      if (!instrumentToReset) {
+        console.log(`Could not reset night allowance. Instrument not found: ${instrId}`)
+        return
+      }
+
+      instrumentToReset.nightAllowance = originalNightAllowance
+
+      await instrumentToReset.save()
+
+      console.log(`Reset night allowance for ${instrumentToReset.name}:`, {
+        restoredNightAllowance: originalNightAllowance
+      })
+    } catch (error) {
+      console.log('Error resetting timed experiment night allowance:', error)
     }
+  }, timedExperimentTotalSeconds * 1000)
+}
 
-    experimentsByDataset[exp.datasetName].push(exp)
-  })
+//helpers for total experiment time 
+const getRepeatCount = repeatLoops =>
+  Array.isArray(repeatLoops)
+    ? repeatLoops.reduce((sum, loop) => sum + (Number(loop?.count) || 0), 0)
+    : 0
 
-  const minGaps = Object.entries(experimentsByDataset)
-    .map(([datasetName, datasetExperiments]) => {
-      const minGapSeconds = getTimedNightMaxExperimentSeconds(datasetExperiments)
+const getRepeatLagSeconds = repeatLoops =>
+  Array.isArray(repeatLoops)
+    ? repeatLoops.reduce(
+        (sum, loop) =>
+          sum + parseDelayToDuration(loop?.lag).asSeconds() * (Number(loop?.count) || 0),
+        0
+      )
+    : 0
 
-      console.log(`Timed gap for dataset ${datasetName}:`, minGapSeconds)
+const getTimedEstimateSeconds = ({
+  oneSetSeconds = 0,
+  initialDelay,
+  repeatLoops
+}) => {
+  const initialDelaySeconds = parseDelayToDuration(initialDelay).asSeconds()
+  const repeatLagSeconds = getRepeatLagSeconds(repeatLoops)
+  const repeatCount = getRepeatCount(repeatLoops)
+  const repeatedRunSeconds = oneSetSeconds * repeatCount
 
-      return minGapSeconds
-    })
-    .filter(gap => gap !== null)
-
-  if (minGaps.length === 0) {
-    return null
-  }
-
-  return Math.min(...minGaps)
+  return oneSetSeconds + initialDelaySeconds + repeatLagSeconds + repeatedRunSeconds
 }

--- a/nomad-rest-api/controllers/submit.js
+++ b/nomad-rest-api/controllers/submit.js
@@ -127,31 +127,19 @@ export const postSubmission = async (req, res) => {
     }
 
     // toremove - uncomment to test socket emit
-    for (let instrumentId in submitData) {
-      //Getting socketId from submitter state
-      const { socketId } = submitter.state.get(instrumentId)
-
-      if (!socketId) {
-        console.log('Error: Client disconnected')
-        return res.status(503).send({ message: 'Client disconnected' })
-      }
-
-      getIO().to(socketId).emit('book', JSON.stringify(submitData[instrumentId]))
-    }
-
     // for (let instrumentId in submitData) {
-    //   const submitterState = submitter.state.get(instrumentId)
-    //   const socketId = submitterState?.socketId
+    //   //Getting socketId from submitter state
+    //   const { socketId } = submitter.state.get(instrumentId)
 
     //   if (!socketId) {
-    //     console.log(
-    //       `No client connected for instrument ${instrumentId} - skipping socket emit in dev`
-    //     )
-    //     continue
+    //     console.log('Error: Client disconnected')
+    //     return res.status(503).send({ message: 'Client disconnected' })
     //   }
 
     //   getIO().to(socketId).emit('book', JSON.stringify(submitData[instrumentId]))
     // }
+
+
 
     res.send()
   } catch (error) {
@@ -347,6 +335,22 @@ export const getAllowance = async (req, res) => {
         const instr = await Instrument.findById(instrId)
         let { dayAllowance, nightAllowance, nightStart, nightEnd, overheadTime } = instr
 
+        const activeTimedExperiments = await Experiment.find({
+          'instrument.id': instrId,
+          // startTime: { $ne: null, $gte: new Date() }, this filters out experiments that start now.
+          startTime: { $ne: null },
+          status: { $in: ['Booked', 'Submitted', 'Available', 'Running'] }
+        }).sort({ datasetName: 1, startTime: 1 })
+
+        const timedNightMaxExperimentSeconds =
+          getTimedNightMaxExperimentSecondsByDataset(activeTimedExperiments)
+
+        console.log(
+          `Timed night max experiment duration for instrument ${instr.name}:`,
+          timedNightMaxExperimentSeconds
+        )
+
+
         const usrSamples = new Set()
 
         await Promise.all(
@@ -415,7 +419,8 @@ export const getAllowance = async (req, res) => {
           nightEnd,
           overheadTime,
           nightExpt: instr.status.summary.nightExpt,
-          dayExpt: instr.status.summary.dayExpt
+          dayExpt: instr.status.summary.dayExpt,
+          timedNightMaxExperimentSeconds
         })
       })
     )
@@ -593,4 +598,71 @@ const parseDelayToDuration = value => {
   if (!value) return moment.duration(0)
   const [hours = 0, minutes = 0] = value.split(':').map(Number)
   return moment.duration({ hours, minutes })
+}
+
+// Calculates the smallest gap between start times for a single timed experiment dataset.
+// Duplicate start times are ignored because multiple experiments in the same set can share a start time.
+const getTimedNightMaxExperimentSeconds = experiments => {
+  if (!Array.isArray(experiments) || experiments.length < 2) {
+    return null
+  }
+
+  const sortedStartTimes = experiments
+    .map(exp => exp.startTime)
+    .filter(Boolean)
+    .map(startTime => moment(startTime))
+    .filter(startTime => startTime.isValid())
+    .sort((a, b) => a.valueOf() - b.valueOf())
+
+  if (sortedStartTimes.length < 2) {
+    return null
+  }
+
+  let minGapSeconds = null
+
+  for (let i = 1; i < sortedStartTimes.length; i++) {
+    const gapSeconds = sortedStartTimes[i].diff(sortedStartTimes[i - 1], 'seconds')
+
+    if (gapSeconds > 0 && (minGapSeconds === null || gapSeconds < minGapSeconds)) {
+      minGapSeconds = gapSeconds
+    }
+  }
+
+  return minGapSeconds
+}
+
+// Calculates the smallest timed repeat gap per dataset, then returns the smallest of those.
+// This avoids unrelated timed experiments on the same instrument creating artificial tiny gaps.
+const getTimedNightMaxExperimentSecondsByDataset = experiments => {
+  if (!Array.isArray(experiments) || experiments.length < 2) {
+    return null
+  }
+
+  const experimentsByDataset = {}
+
+  experiments.forEach(exp => {
+    if (!exp.datasetName || !exp.startTime) return
+
+    if (!experimentsByDataset[exp.datasetName]) {
+      experimentsByDataset[exp.datasetName] = []
+    }
+
+    experimentsByDataset[exp.datasetName].push(exp)
+  })
+
+  const minGaps = Object.entries(experimentsByDataset)
+    .map(([datasetName, datasetExperiments]) => {
+      const minGapSeconds = getTimedNightMaxExperimentSeconds(datasetExperiments)
+
+      console.log(`Timed gap for dataset ${datasetName}:`, minGapSeconds)
+
+      return minGapSeconds
+    })
+    .filter(gap => gap !== null)
+
+  if (minGaps.length === 0) {
+    return null
+  }
+
+  return Math.min(...minGaps)
 }


### PR DESCRIPTION
#50 
-   temporarily reduce the instruments nightAllowance in the backend, assuming only one timed experiment is active/submitted at a time for this implementation.
- When a timed experiment is submitted, the backend now calculates the minimum positive repeat lag from the loop parameters.
- nightAllowance is updated to the smaller value between the current night allowance and the minimum timed lag.
- After totalDuration has passed, the callback is called to reset the nightAllowance back to the original value at the submission time. 
- Note: the total experiment duration is also computed in the TimedExperimentModal 