### PR TITLE
add clock to p column

### DIFF
--- a/nomad-front-end/src/components/StatusTabs/StatusTable/StatusTable.jsx
+++ b/nomad-front-end/src/components/StatusTabs/StatusTable/StatusTable.jsx
@@ -181,7 +181,19 @@ const StatusTable = props => {
       title: 'P',
       dataIndex: 'priority',
       align: 'center',
-      render: text => text && <ExclamationCircleOutlined style={{ color: '#389e0d' }} />
+      render: (text, record) => {
+        const hasTimedExperiment = !!record.startTime
+
+        if (hasTimedExperiment) {
+          return <ClockCircleOutlined style={{ color: '#1890ff' }} />
+        }
+
+        if (text) {
+          return <ExclamationCircleOutlined style={{ color: '#389e0d' }} />
+        }
+
+        return null
+      }
     },
     {
       title: 'Status',


### PR DESCRIPTION
- Added status table support for displaying a clock icon for timed experiments in the P column.  #50 
- if startTime is not null: show the priority clock, elif priority: show the priority icon. 
- THe historic non-timed experiment behaviour has been tested. Timed experiment display still needs full verification.